### PR TITLE
neonippori: Use zero-width spaces in escape_ass_text

### DIFF
--- a/yt_dlp/neonippori.py
+++ b/yt_dlp/neonippori.py
@@ -273,9 +273,14 @@ def write_comment(f, c: Comment, row, width, height, bottomReserved, fontsize, d
 
 def escape_ass_text(s):
     def process_blanks(s):
-        a, b, c = re.search(r'(^\s*)(.+?)(\s*$)', s).groups()
-        return ''.join(('\u2007' * len(a), b, '\u2007' * len(c))) or ' '
-    return r'\N'.join(map(process_blanks, re.sub(r'([\\}{])', r'\\\1', s).splitlines()))
+        if len(s) == 0:
+            return ' '
+        if s[0] in (' ', '\t'):
+            s = '\u200b' + s
+        if s[-1] in (' ', '\t'):
+            s = s + '\u200b'
+        return s
+    return r'\N'.join(map(process_blanks, re.sub(r'([}{])', r'\\\1', s.replace('\\', '\\\u200b')).splitlines()))
 
 
 def maximum_line_length(s: str):


### PR DESCRIPTION
Preserve original spacing and properly escape backslashes. See https://github.com/m13253/danmaku2ass/pull/54

**IMPORTANT**: PRs without the template will be CLOSED

### Description of your *pull request* and other information

</details>

<!--

Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your *pull request* and is worded well enough to be understood. Provide as much **context and examples** as possible

-->

Use zero-width spaces instead of figure spaces to preserve intended spacing, and escape backslashes in comments. Note: escaping curly brackets is only supported by libass (https://github.com/libass/libass/commit/a6fe61a3990afec7bed1d7e781020f1cbff9d5b5), not XySubFilter.


<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--

# PLEASE FOLLOW THE GUIDE BELOW

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
- Use *Preview* tab to see how your *pull request* will actually look like

-->

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [x] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) and [ran relevant tests](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions)

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [ ] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))
